### PR TITLE
Serve the research app at specific location

### DIFF
--- a/js/widget.js
+++ b/js/widget.js
@@ -13,7 +13,7 @@ async function render({model, el}) {
     // Create iframe
     const iframe = document.createElement('iframe');
     // iframe.src = 'https://web.wwtassets.org/research/latest/?origin=' + location.origin;
-    iframe.src = serverUrl + "/?origin=" + location.origin;
+    iframe.src = serverUrl + "/research/?origin=" + location.origin;
     iframe.style.width = "100%";
     iframe.style.height = "400px";
     iframe.style.border = "none";

--- a/src/ipywwt/__init__.py
+++ b/src/ipywwt/__init__.py
@@ -21,7 +21,7 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = "unknown"
 
 STATIC = pathlib.Path(__file__).parent / "static"
-RESEARCH_APP = pathlib.Path(__file__).parent / "web_static" / "research"
+RESEARCH_APP = pathlib.Path(__file__).parent / "web_static"
 DEFAULT_SURVEYS_URL = "https://gist.githubusercontent.com/Carifio24/e8b02488d43a0e4381648fe06c100739/raw/surveys.xml"
 
 
@@ -70,7 +70,10 @@ class WWTWidget(anywidget.AnyWidget, BaseWWTWidget):
 
         def run_server():
             os.chdir(self._research_app_path)
-            subprocess.run(["python", "-m", "http.server", str(self._port)], check=True)
+            subprocess.run(
+                ["python", "-m", "http.server", str(self._port), "--bind", "0.0.0.0"],
+                check=True,
+            )
 
         server_thread = threading.Thread(target=run_server, daemon=True)
         server_thread.start()


### PR DESCRIPTION
This ensures that the research app is served as a specific `/research` end point, to better interoperate with nginx configurations.